### PR TITLE
Thesis #3: Hoist truthiness check in array loop

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,11 +9,9 @@ function toVal(mix) {
 		if (isArray(mix)) {
 			var len=mix.length;
 			for (k=0; k < len; k++) {
-				if (mix[k]) {
-					if (y = toVal(mix[k])) {
-						str && (str += ' ');
-						str += y;
-					}
+				if (y = toVal(mix[k])) {
+					str && (str += ' ');
+					str += y;
 				}
 			}
 		} else {


### PR DESCRIPTION
References #3

Self-reported metric: 5877842.0000
Baseline: 5797883.0000
Summary: Removed redundant truthiness check before toVal() call in array loop. The inner toVal() already handles falsy values correctly, so the outer check was unnecessary overhead. Performance improved ~1.4% (5.80M to 5.88M ops/sec).